### PR TITLE
v0.1.1: Fix/help spelling

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,10 +19,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use: `roll [--number, -n dice_number] --dice, -d dice_type [options]
-  roll dice_number dice_type [options]
-  roll dice_type [options]
-  roll --help, -h`,
+	Use: `droll [--number, -n dice_number] --dice, -d dice_type [options]
+  droll dice_number dice_type [options]
+  droll dice_type [options]
+  droll --help, -h`,
 	Short: "dRoll is a CLI dice roller",
 	Long: `A Fast and Easy to use CLI dice roller built
 with love and passion by lbAntoine in Go.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -23,7 +23,7 @@ var rootCmd = &cobra.Command{
   droll dice_number dice_type [options]
   droll dice_type [options]
   droll --help, -h`,
-	Short: "dRoll is a CLI dice roller",
+	Short: "dRoll is a CLI dice roller: v0.1.1",
 	Long: `A Fast and Easy to use CLI dice roller built
 with love and passion by lbAntoine in Go.
 Complete documentation is available at https://github.com/lbAntoine/droll`,

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package main
+
+// Version information
+const (
+	Version = "0.1.1"
+)


### PR DESCRIPTION
Version 0.1.0 required a fix for a spelling mistake.

The help menu used to reference the application as `roll`, it now refers it with its correct executable name: `droll`.

Also added a `version.go` file containing version information. As it's not a major update, it could be taken into that fix.