### PR TITLE
Feature merge: Coin Flip Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work.sum
 .env
 **/*config.yaml
 dist
+_notes

--- a/README.md
+++ b/README.md
@@ -48,39 +48,49 @@ Download the latest release for your platform from the [Releases](https://github
 
 ## 🎯 Usage Examples
 
-### Basic Rolling
+### Dice Rolling
 
 ```bash
 # Roll a single six-sided die
-droll 6
+droll roll 6
 
 # Roll 3 six-sided dice
-droll 3 6
+droll roll 3 6
 
 # Roll a 20-sided die
-droll 20
+droll roll 20
 ```
 
-### Advanced Options
+#### Advanced Options
 
 ```bash
 # Roll 2 d20 and show the sum
-droll -n 2 -d 20 --sum
+droll roll -n 2 -d 20 --sum
 
 # Roll 4 d6 and show individual throws
-droll -n 4 -d 6 --unit
+droll roll -n 4 -d 6 --unit
 
 # Roll with comment flag for D&D-style messages
-droll -n 1 -d 20 -c
+droll roll -n 1 -d 20 -c
 ```
 
-### Flags
+#### Flags
 
 - `-n, --number`: Number of dice to roll
 - `-d, --dice`: Type of dice to roll
 - `--sum`: Only show the total sum
 - `--unit`: Show individual dice throws
 - `-c, --comment`: Enable D&D-style roll messages
+
+### Coin Flipping
+
+```bash
+# Flip a single coin
+droll flip
+
+# Flip 3 coins
+droll flip 3
+```
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ droll roll -n 2 -d 20 --sum
 droll roll -n 4 -d 6 --unit
 
 # Roll with comment flag for D&D-style messages
-droll roll -n 1 -d 20 -c
+droll roll -n 1 -d 20 -v
 ```
 
 #### Flags
@@ -80,7 +80,7 @@ droll roll -n 1 -d 20 -c
 - `-d, --dice`: Type of dice to roll
 - `--sum`: Only show the total sum
 - `--unit`: Show individual dice throws
-- `-c, --comment`: Enable D&D-style roll messages
+- `-v, --verbose`: Enable D&D-style roll messages
 
 ### Coin Flipping
 
@@ -90,7 +90,14 @@ droll flip
 
 # Flip 3 coins
 droll flip 3
+
+# Flip 3 coin and get summary
+droll flip 4 -v
 ```
+
+#### Flags
+
+- `-v`, `--verbose`: Append a summary of the flips to the output.
 
 ## 🤝 Contributing
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/lbAntoine/droll/internal/commands"
 	"github.com/spf13/cobra"
 )
 
@@ -170,6 +171,8 @@ func printVerboseMessage(results []int) {
 }
 
 func init() {
+	rootCmd.AddCommand(commands.NewFlipCommand())
+
 	rootCmd.Flags().IntVarP(&diceNumber, "number", "n", 0, "Number of dice to roll")
 	rootCmd.Flags().IntVarP(&diceType, "dice", "d", 0, "Type of dice to roll (e.g., 6 for d6)")
 	rootCmd.Flags().BoolVar(&showSum, "sum", false, "Only show the sum of dice")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,28 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/lbAntoine/droll/internal/commands"
 	"github.com/spf13/cobra"
 )
 
-var (
-	diceNumber int
-	diceType   int
-	showSum    bool
-	showUnit   bool
-	verbose    bool
-)
-
 var rootCmd = &cobra.Command{
-	Use: `droll [--number, -n dice_number] --dice, -d dice_type [options]
-  droll dice_number dice_type [options]
-  droll dice_type [options]
-  droll --help, -h`,
+	Use:   "droll",
 	Short: "dRoll is a CLI dice roller: v0.1.1",
 	Long: `A Fast and Easy to use CLI dice roller built
 with love and passion by lbAntoine in Go.
@@ -34,150 +20,12 @@ Complete documentation is available at https://github.com/lbAntoine/droll`,
 			cmd.Help()
 			return
 		}
-
-		processCmd(args)
 	},
 }
 
-func processCmd(args []string) {
-	parseArgs(args)
-
-	if diceNumber == 0 {
-		diceNumber = 1
-	}
-
-	if diceType <= 0 {
-		fmt.Println("Error: Dice must be a positive number > 0")
-		os.Exit(1)
-	}
-
-	results := rollDice(diceNumber, diceType)
-	displayResults(results)
-}
-
-func parseArgs(args []string) {
-	if diceNumber == 0 && diceType == 0 {
-		if len(args) == 1 {
-			if d, err := strconv.Atoi(args[0]); err == nil {
-				diceNumber = 1
-				diceType = d
-			}
-		}
-
-		if len(args) >= 2 {
-			if n, err := strconv.Atoi(args[0]); err == nil {
-				diceNumber = n
-			}
-			if d, err := strconv.Atoi(args[1]); err == nil {
-				diceType = d
-			}
-		}
-	}
-}
-
-func rollDice(number, diceType int) []int {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	results := make([]int, number)
-	for i := range number {
-		results[i] = r.Intn(diceType) + 1
-	}
-
-	return results
-}
-
-func calculateSum(results []int) int {
-	sum := 0
-	for _, r := range results {
-		sum += r
-	}
-
-	return sum
-}
-
-func displayResults(results []int) {
-	sum := calculateSum(results)
-
-	fmt.Printf("%d dice rolled (d%d):\n", diceNumber, diceType)
-
-	if diceNumber == 1 {
-		fmt.Printf("Rolled: %d\n", results[0])
-		if verbose {
-			printVerboseMessage(results)
-		}
-		return
-	}
-
-	if showSum && !showUnit {
-		fmt.Printf("Sum: %d\n", sum)
-		if verbose {
-			printVerboseMessage(results)
-		}
-		return
-	}
-
-	if showUnit && !showSum {
-		fmt.Println("Throws:")
-		for _, result := range results {
-			fmt.Printf("  * %d\n", result)
-		}
-		if verbose {
-			printVerboseMessage(results)
-		}
-		return
-	}
-
-	fmt.Printf("Sum: %d\n", sum)
-	fmt.Println("Throws:")
-	for _, result := range results {
-		fmt.Printf("  * %d\n", result)
-	}
-
-	if verbose {
-		printVerboseMessage(results)
-	}
-}
-
-func printVerboseMessage(results []int) {
-	if diceType == 20 {
-		for _, result := range results {
-			switch result {
-			case 20:
-				fmt.Printf("Natural 20!! Critical success!!!\n")
-				return
-			case 1:
-				fmt.Printf("Natural 1... Critical failure!!!\n")
-				return
-			}
-		}
-	}
-
-	sum := calculateSum(results)
-	maxPossible := diceNumber * diceType
-	percentage := float64(sum) / float64(maxPossible)
-
-	switch {
-	case percentage >= 0.9:
-		fmt.Printf("Exceptional roll! The gods smile upon you!\n")
-	case percentage >= 0.7:
-		fmt.Printf("Good roll! Fortune favors you today.\n")
-	case percentage >= 0.5:
-		fmt.Printf("Decent roll. Could be better, could be worse.\n")
-	case percentage >= 0.3:
-		fmt.Printf("Not great. The fates are testing you.\n")
-	default:
-		fmt.Printf("Abysmal roll!! Better luck next time... I guess?\n")
-	}
-}
-
 func init() {
+	rootCmd.AddCommand(commands.NewRollCommand())
 	rootCmd.AddCommand(commands.NewFlipCommand())
-
-	rootCmd.Flags().IntVarP(&diceNumber, "number", "n", 0, "Number of dice to roll")
-	rootCmd.Flags().IntVarP(&diceType, "dice", "d", 0, "Type of dice to roll (e.g., 6 for d6)")
-	rootCmd.Flags().BoolVar(&showSum, "sum", false, "Only show the sum of dice")
-	rootCmd.Flags().BoolVar(&showUnit, "unit", false, "Only show individual dice throws")
-	rootCmd.Flags().BoolVarP(&verbose, "comment", "c", false, "Show verbose DnD-style messages")
 }
 
 func Execute() {

--- a/internal/commands/coinflip.go
+++ b/internal/commands/coinflip.go
@@ -11,7 +11,7 @@ import (
 )
 
 func NewFlipCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "flip [number]",
 		Short: "Flip a coin",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -29,6 +29,9 @@ func NewFlipCommand() *cobra.Command {
 			displayFlipResults(results)
 		},
 	}
+
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Display detailed results with summary")
+	return cmd
 }
 
 func flipCoin(numFlips int) []string {
@@ -48,7 +51,22 @@ func flipCoin(numFlips int) []string {
 
 func displayFlipResults(results []string) {
 	fmt.Printf("%d coin flips:\n", len(results))
+	headsCount, tailsCount := 0, 0
+
 	for i, res := range results {
 		fmt.Printf("  - Flip %d: %s\n", i+1, res)
+		switch res {
+		case "Heads":
+			headsCount++
+		case "Tails":
+			tailsCount++
+		}
+	}
+
+	if verbose {
+		total := len(results)
+		fmt.Printf("\nSummary:\n")
+		fmt.Printf("  - Heads: %d (%.2f%%)\n", headsCount, float64(headsCount)/float64(total)*100)
+		fmt.Printf("  - Tails: %d (%.2f%%)\n", tailsCount, float64(tailsCount)/float64(total)*100)
 	}
 }

--- a/internal/commands/coinflip.go
+++ b/internal/commands/coinflip.go
@@ -1,0 +1,54 @@
+package commands
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func NewFlipCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "flip [number]",
+		Short: "Flip a coin",
+		Run: func(cmd *cobra.Command, args []string) {
+			numFlips := 1
+			if len(args) > 0 {
+				if n, err := strconv.Atoi(args[0]); err == nil && n > 0 {
+					numFlips = n
+				} else {
+					fmt.Println("Error: Invalid number of flips")
+					os.Exit(1)
+				}
+			}
+
+			results := flipCoin(numFlips)
+			displayFlipResults(results)
+		},
+	}
+}
+
+func flipCoin(numFlips int) []string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	results := make([]string, numFlips)
+
+	for i := range numFlips {
+		if r.Intn(2) == 0 {
+			results[i] = "Heads"
+		} else {
+			results[i] = "Tails"
+		}
+	}
+
+	return results
+}
+
+func displayFlipResults(results []string) {
+	fmt.Printf("%d coin flips:\n", len(results))
+	for i, res := range results {
+		fmt.Printf("Flip %d: %s\n", i+1, res)
+	}
+}

--- a/internal/commands/coinflip.go
+++ b/internal/commands/coinflip.go
@@ -49,6 +49,6 @@ func flipCoin(numFlips int) []string {
 func displayFlipResults(results []string) {
 	fmt.Printf("%d coin flips:\n", len(results))
 	for i, res := range results {
-		fmt.Printf("Flip %d: %s\n", i+1, res)
+		fmt.Printf("  - Flip %d: %s\n", i+1, res)
 	}
 }

--- a/internal/commands/coinflip_test.go
+++ b/internal/commands/coinflip_test.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestFlipCoin(t *testing.T) {
+	numFlips := 10
+	results := flipCoin(numFlips)
+
+	if len(results) != numFlips {
+		t.Errorf("Expected %d results, got %d", numFlips, len(results))
+	}
+
+	for _, result := range results {
+		if result != "Heads" && result != "Tails" {
+			t.Errorf("Unexpected result: %s", result)
+		}
+	}
+}
+
+func TestDisplayFlipResults(t *testing.T) {
+	results := []string{"Heads", "Tails", "Heads"}
+	expectedOutput := "3 coin flips:\n  - Flip 1: Heads\n  - Flip 2: Tails\n  - Flip 3: Heads\n"
+
+	output := CaptureOutput(func() {
+		displayFlipResults(results)
+	})
+
+	if output != expectedOutput {
+		t.Errorf("Expected output:\n%s\nGot:\n%s", expectedOutput, output)
+	}
+}
+
+func TestNewFlipCommand(t *testing.T) {
+	cmd := NewFlipCommand()
+
+	// Test default behavior (1 flip)
+	output := CaptureOutput(func() {
+		cmd.SetArgs([]string{})
+		cmd.Execute()
+	})
+	if !strings.Contains(output, "1 coin flips:") {
+		t.Errorf("Expected output to contain '1 coin flips:', got: %s", output)
+	}
+
+	// Test with valid number of flips
+	output = CaptureOutput(func() {
+		cmd.SetArgs([]string{"5"})
+		cmd.Execute()
+	})
+	if !strings.Contains(output, "5 coin flips:") {
+		t.Errorf("Expected output to contain '5 coin flips:', got: %s", output)
+	}
+
+	// Test with invalid input
+	// exitCode := captureExitCode(func() {
+	// 	cmd.SetArgs([]string{"invalid"})
+	// 	cmd.Execute()
+	// })
+	// if exitCode != 1 {
+	// 	t.Errorf("Expected exit code 1 for invalid input, got: %d", exitCode)
+	// }
+}
+
+// Helper function to capture output
+func CaptureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		buf.ReadFrom(r)
+		close(done)
+	}()
+
+	f()
+
+	w.Close()
+	<-done
+	os.Stdout = old
+
+	return buf.String()
+}
+
+// Helper function to capture exit code
+// func captureExitCode(f func()) int {
+// 	var code int
+// 	oldExit := os.Exit
+// 	defer func() { os.Exit = oldExit }()
+//
+// 	os.Exit = func(c int) {
+// 		code = c
+// 		panic("exit") // Use panic to simulate os.Exit
+// 	}
+//
+// 	defer func() {
+// 		if r := recover(); r != nil && r != "exit" {
+// 			panic(r) // Re-throw unexpected panics
+// 		}
+// 	}()
+//
+// 	f()
+// 	return code
+// }

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -1,0 +1,9 @@
+package commands
+
+var (
+	diceNumber int
+	diceType   int
+	showSum    bool
+	showUnit   bool
+	verbose    bool
+)

--- a/internal/commands/diceroll.go
+++ b/internal/commands/diceroll.go
@@ -1,0 +1,1 @@
+package commands

--- a/internal/commands/diceroll.go
+++ b/internal/commands/diceroll.go
@@ -10,14 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	diceNumber int
-	diceType   int
-	showSum    bool
-	showUnit   bool
-	verbose    bool
-)
-
 func NewRollCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "roll [number] [dice_type]",
@@ -31,7 +23,7 @@ func NewRollCommand() *cobra.Command {
 	cmd.Flags().IntVarP(&diceType, "dice", "d", 0, "Type of dice to roll (e.g., 6 for d6)")
 	cmd.Flags().BoolVar(&showSum, "sum", false, "Only show the sum of dice")
 	cmd.Flags().BoolVar(&showUnit, "unit", false, "Only show individual dice throws")
-	cmd.Flags().BoolVarP(&verbose, "comment", "c", false, "Show verbose DnD-style messages")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show verbose DnD-style messages")
 
 	return cmd
 }

--- a/internal/commands/diceroll.go
+++ b/internal/commands/diceroll.go
@@ -1,1 +1,168 @@
 package commands
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	diceNumber int
+	diceType   int
+	showSum    bool
+	showUnit   bool
+	verbose    bool
+)
+
+func NewRollCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "roll [--number, -n dice_number] --dice, -d dice_type [options]",
+		Short: "Roll dice with specified dices",
+		Run: func(cmd *cobra.Command, args []string) {
+			processCmd(args)
+		},
+	}
+
+	cmd.Flags().IntVarP(&diceNumber, "number", "n", 0, "Number of dice to roll")
+	cmd.Flags().IntVarP(&diceType, "dice", "d", 0, "Type of dice to roll (e.g., 6 for d6)")
+	cmd.Flags().BoolVar(&showSum, "sum", false, "Only show the sum of dice")
+	cmd.Flags().BoolVar(&showUnit, "unit", false, "Only show individual dice throws")
+	cmd.Flags().BoolVarP(&verbose, "comment", "c", false, "Show verbose DnD-style messages")
+
+	return cmd
+}
+
+func processCmd(args []string) {
+	parseArgs(args)
+
+	if diceNumber == 0 {
+		diceNumber = 1
+	}
+
+	if diceType <= 0 {
+		fmt.Println("Error: Dice must be a positive number > 0")
+		os.Exit(1)
+	}
+
+	results := rollDice(diceNumber, diceType)
+	displayResults(results)
+}
+
+func parseArgs(args []string) {
+	if diceNumber == 0 && diceType == 0 {
+		if len(args) == 1 {
+			if d, err := strconv.Atoi(args[0]); err == nil {
+				diceNumber = 1
+				diceType = d
+			}
+		}
+
+		if len(args) >= 2 {
+			if n, err := strconv.Atoi(args[0]); err == nil {
+				diceNumber = n
+			}
+			if d, err := strconv.Atoi(args[1]); err == nil {
+				diceType = d
+			}
+		}
+	}
+}
+
+func rollDice(number, diceType int) []int {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	results := make([]int, number)
+	for i := range number {
+		results[i] = r.Intn(diceType) + 1
+	}
+
+	return results
+}
+
+func calculateSum(results []int) int {
+	sum := 0
+	for _, r := range results {
+		sum += r
+	}
+
+	return sum
+}
+
+func displayResults(results []int) {
+	sum := calculateSum(results)
+
+	fmt.Printf("%d dice rolled (d%d):\n", diceNumber, diceType)
+
+	if diceNumber == 1 {
+		fmt.Printf("Rolled: %d\n", results[0])
+		if verbose {
+			printVerboseMessage(results)
+		}
+		return
+	}
+
+	if showSum && !showUnit {
+		fmt.Printf("Sum: %d\n", sum)
+		if verbose {
+			printVerboseMessage(results)
+		}
+		return
+	}
+
+	if showUnit && !showSum {
+		fmt.Println("Throws:")
+		for _, result := range results {
+			fmt.Printf("  * %d\n", result)
+		}
+		if verbose {
+			printVerboseMessage(results)
+		}
+		return
+	}
+
+	fmt.Printf("Sum: %d\n", sum)
+	fmt.Println("Throws:")
+	for _, result := range results {
+		fmt.Printf("  * %d\n", result)
+	}
+
+	if verbose {
+		printVerboseMessage(results)
+	}
+}
+
+func printVerboseMessage(results []int) {
+	if diceType == 20 {
+		for _, result := range results {
+			switch result {
+			case 20:
+				fmt.Printf("Natural 20!! Critical success!!!\n")
+				return
+			case 1:
+				fmt.Printf("Natural 1... Critical failure!!!\n")
+				return
+			}
+		}
+	}
+
+	sum := calculateSum(results)
+	maxPossible := diceNumber * diceType
+	percentage := float64(sum) / float64(maxPossible)
+
+	switch {
+	case percentage >= 0.9:
+		fmt.Printf("Exceptional roll! The gods smile upon you!\n")
+	case percentage >= 0.7:
+		fmt.Printf("Good roll! Fortune favors you today.\n")
+	case percentage >= 0.5:
+		fmt.Printf("Decent roll. Could be better, could be worse.\n")
+	case percentage >= 0.3:
+		fmt.Printf("Not great. The fates are testing you.\n")
+	default:
+		fmt.Printf("Abysmal roll!! Better luck next time... I guess?\n")
+	}
+}

--- a/internal/commands/diceroll.go
+++ b/internal/commands/diceroll.go
@@ -20,7 +20,7 @@ var (
 
 func NewRollCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "roll [--number, -n dice_number] --dice, -d dice_type [options]",
+		Use:   "roll [number] [dice_type]",
 		Short: "Roll dice with specified dices",
 		Run: func(cmd *cobra.Command, args []string) {
 			processCmd(args)

--- a/internal/commands/diceroll_test.go
+++ b/internal/commands/diceroll_test.go
@@ -1,4 +1,4 @@
-package cmd
+package commands
 
 import (
 	"bytes"


### PR DESCRIPTION

## Coin flip command

The coin flip command has been added and let the user flip coins.

```bash
# Flip one coin
droll flip

# Flip 3 coins
droll flip 3

# Flip 3 coins and show the summary
droll flip 3 -v
```

This has been added to the `README.md` documentation.

## Refactoring

Refactoring the codebase was necessary in order to separate different commands and common variables. This still need some work, but its introduction in this feature is already out of context. Another branch will be opened to address this after merge will be done.

feature/coinflip

- **coin flip v1**
- **relocate dice command**
- **better tests**
- **feature(coinflip): documentation added**
- **feature(coinflip): Added verbose flag**
